### PR TITLE
feat: gemma4:31b default model, backup model retry, remove tiktoken

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,25 @@
+name: bandit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install bandit
+      run: pip install "bandit[toml]>=1.8"
+
+    - name: Run bandit
+      run: bandit -c pyproject.toml -r pdf_renamer.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install ".[dev]"
         
     - name: Run tests with pytest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .aider*
 .env
-venv/
+.venv/
 __pycache__/
 launch.json
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+## Development Setup
+
+Install the package with development dependencies:
+
+```bash
+pip install -e ".[dev]"
+```
+
+`prompt.md` must be present in the working directory when running the tool or
+tests that exercise `generate_new_filename` without mocking the file read.
+
+## Testing
+
+Run the full test suite:
+
+```bash
+pytest
+```
+
+Run with coverage:
+
+```bash
+pytest --cov=. --cov-report=term-missing
+```
+
+Tests live in `test_pdf_renamer.py` alongside the source. All Ollama HTTP calls
+and filesystem operations are mocked — no running Ollama instance is required to
+run the tests.
+
+## Code Quality
+
+Format, lint, and security-scan with the dev tools configured in `pyproject.toml`:
+
+```bash
+black pdf_renamer.py test_pdf_renamer.py
+flake8 pdf_renamer.py
+bandit -c pyproject.toml -r pdf_renamer.py
+vulture pdf_renamer.py
+```
+
+Line length is set to 88 characters (Black default). Flake8 is configured to
+match via `[tool.flake8]` in `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -1,90 +1,153 @@
 # PDF Namer
 
-A Python CLI tool that intelligently renames PDF files using LLaMA AI model integration. It extracts text from PDFs and generates meaningful filenames based on the content.
+A CLI tool that renames PDF files using a locally running Ollama LLM. It extracts text from each PDF, sends it to the model, and renames the file to a structured `YYYY.MM.DD - Descriptive Name.pdf` format.
 
-[![Python Tests](https://github.com/max-rousseaupdf-namer/actions/workflows/pytest.yml/badge.svg)](https://github.com/max-rousseaupdf-namer/actions/workflows/pytest.yml)
+[![Python Tests](https://github.com/max-rousseau/pdf-namer/actions/workflows/pytest.yml/badge.svg)](https://github.com/max-rousseau/pdf-namer/actions/workflows/pytest.yml)
 
 ## Features
 
-- Extracts text content from PDF files
-- Uses LLaMA AI to generate meaningful filenames
-- Supports different LLaMA models
-- Includes test mode for safe operation
-- Handles batch processing of multiple PDFs
-- Configurable context window sizes
-- Built-in error handling and validation
+- Extracts text from PDFs using pypdf
+- Queries a local Ollama instance to generate a descriptive filename and infer the document date
+- Produces consistently formatted filenames: `YYYY.MM.DD - Description.pdf`
+- Filenames are capped at 80 characters to stay filesystem-friendly
+- Filters by timestamp pattern by default; `--all-files` bypasses the filter
+- Test mode prompts for confirmation before each rename
+- Optional `--backup-model` flag retries failed fields with a second model
 
-## Prerequisites
+## Architecture
 
-- Python 3.11 or higher
-- Ollama running locally with LLaMA models installed
-- Git (for cloning the repository)
+### Class Diagram
 
-## Installation
+```mermaid
+classDiagram
+    class pdf_renamer {
+        +DEFAULT_MODEL: str
+        +MODEL_CONTEXT_MAP: dict
+        +FAILED_DATE: str
+        +FAILED_FILENAME: str
+        +calculate_context_window(model, prompt) int
+        +extract_pdf_text(pdf_path) str
+        +generate_new_filename(text, original_file, model) tuple
+        +format_filename(date, filename) str
+        +process_pdfs(directory, test_mode, model, all_files, backup_model)
+        +main()
+    }
 
-1. Clone the repository:
-```bash
-git clone https://github.com/max-rousseaupdf-namer.git
-cd pdf-namer
+    class Ollama {
+        <<external>>
+        +POST /api/generate
+    }
+
+    class pypdf {
+        <<library>>
+        +PdfReader
+    }
+
+    pdf_renamer --> Ollama : HTTP POST
+    pdf_renamer --> pypdf : text extraction
 ```
 
-2. Install dependencies:
-```bash
-pip install -r requirements.txt
+### Happy Path Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as pdf-namer (CLI)
+    participant Extractor as extract_pdf_text
+    participant LLM as Ollama (local)
+    participant FS as Filesystem
+
+    User->>CLI: pdf-namer /docs
+    CLI->>FS: list PDF files matching timestamp pattern
+    FS-->>CLI: [2024_01_15_13_00_00_scan.pdf, ...]
+    CLI->>Extractor: extract_pdf_text(pdf_path)
+    Extractor-->>CLI: raw text string
+    CLI->>LLM: POST /api/generate with prompt + text
+    LLM-->>CLI: {"date": "2024.01.15", "filename": "Verizon MyBill"}
+    CLI->>FS: rename to "2024.01.15 - Verizon MyBill.pdf"
+    FS-->>CLI: success
+    CLI-->>User: File renamed successfully
 ```
 
 ## Usage
 
-Basic usage:
-```bash
-python pdf_renamer.py /path/to/pdf/directory
+```
+pdf-namer [OPTIONS] SCAN_DIRECTORY
 ```
 
-Options:
-- `--test-mode`: Run without actually renaming files (recommended for first use)
-- `--model`: Specify which LLaMA model to use (default: llama3.1:70b-instruct-q8_0)
-- `--all-files`: Process all PDF files regardless of filename pattern
+| Option | Description |
+|---|---|
+| `--test-mode` | Prompt before each rename instead of renaming automatically |
+| `--model TEXT` | Ollama model to use (default: `gemma4:31b`) |
+| `--all-files` | Process all PDFs, not just those matching the timestamp pattern |
+| `--backup-model TEXT` | Fallback model used when the primary fails to extract date or filename |
 
-Example with options:
-```bash
-python pdf_renamer.py --test-mode --model "llama3.1:70b-instruct-q8_0" /path/to/pdfs
-```
+### Examples
 
-## File Naming Convention
-
-By default, the script processes files matching the pattern:
-`YYYY_MM_DD_HH_MM_SS_*.pdf`
-
-Output format:
-`YYYY.MM.DD - Descriptive Name.pdf`
-
-## Development
-
-### Running Tests
+Rename all timestamped PDFs in a directory using the default model:
 
 ```bash
-pytest
+pdf-namer /path/to/pdfs
 ```
 
-For coverage report:
+Preview renames interactively before committing:
+
 ```bash
-pytest --cov=. --cov-report=term-missing
+pdf-namer --test-mode /path/to/pdfs
 ```
 
-### Contributing
+Use a specific primary model with a lighter backup for failed fields:
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+```bash
+pdf-namer --model gemma4:31b --backup-model gemma3:27b /path/to/pdfs
+```
+
+Process every PDF in the directory, bypassing the timestamp filter:
+
+```bash
+pdf-namer --all-files /path/to/pdfs
+```
+
+### File Naming Convention
+
+By default, only files whose names contain a timestamp segment are processed:
+
+```
+2024_01_15_13_00_00_scan.pdf  ->  2024.01.15 - Verizon MyBill.pdf
+```
+
+Use `--all-files` to process PDFs with any filename.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11 or higher
+- [Ollama](https://ollama.com) running locally with at least one supported model pulled
+
+Supported models (others fall back to a 2048-token context):
+
+- `gemma4:31b`
+- `gemma3:27b`
+- `llama3.1:70b-instruct-q8_0`
+- `llama3.1:8b-instruct-fp16`
+- `llama3.2:3b-instruct-fp16`
+
+### Install
+
+```bash
+git clone https://github.com/max-rousseau/pdf-namer.git
+cd pdf-namer
+pip install .
+```
+
+Ollama must be running and the chosen model must be available before invoking `pdf-namer`:
+
+```bash
+ollama serve
+ollama pull gemma4:31b
+```
 
 ## License
 
-This project is licensed under the BSD 2-Clause License - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-- More than 90% of this project was developed using [Aider](https://github.com/Aider-AI/aider), an AI pair programming tool
-- Uses the Ollama API for LLaMA model integration
-- Built with PyPDF for PDF text extraction
+BSD 2-Clause — see [LICENSE](LICENSE).

--- a/pdf_renamer.py
+++ b/pdf_renamer.py
@@ -206,8 +206,10 @@ def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool =
             print(f"Original filename:\t{pdf_file.name}")
             print(f"New filename:\t{new_filename}")
 
-            # Remove .pdf extension if it exists in new_filename
+            # Remove .pdf extension and trailing "..." if they exist
             new_filename = new_filename.replace('.pdf', '')
+            if new_filename.endswith('...'):
+                new_filename = new_filename[:-3].rstrip()
             
             if test_mode:
                 if click.confirm("Do you want to rename this file?", default=False):

--- a/pdf_renamer.py
+++ b/pdf_renamer.py
@@ -1,32 +1,86 @@
+"""
+Module: pdf_renamer
+
+Purpose:
+    CLI tool that renames PDF files using a locally running Ollama LLM instance.
+    Text is extracted from each PDF and sent to the model, which returns a
+    structured JSON response containing a descriptive filename and an inferred
+    document date. The file is then renamed to ``YYYY.MM.DD - Description.pdf``.
+
+Classes:
+    None
+
+Functions:
+    - calculate_context_window: Determine the num_ctx value to send to Ollama.
+    - extract_pdf_text: Read all text from a PDF file.
+    - generate_new_filename: Query the LLM and parse a (date, filename) tuple.
+    - format_filename: Assemble the final filename string from date and name parts.
+    - process_pdfs: Iterate over PDFs in a directory and rename them.
+
+Usage Example:
+    pdf-namer /path/to/directory
+    pdf-namer --test-mode --model gemma3:27b /path/to/directory
+    pdf-namer --all-files --backup-model gemma3:27b /path/to/directory
+
+Happy Path Flow:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as pdf-namer (CLI)
+    participant Extractor as extract_pdf_text
+    participant LLM as Ollama (local)
+    participant FS as Filesystem
+
+    User->>CLI: pdf-namer /docs
+    CLI->>FS: list PDF files
+    FS-->>CLI: [2024_01_15_report.pdf, ...]
+    CLI->>Extractor: extract_pdf_text(pdf_path)
+    Extractor-->>CLI: raw text
+    CLI->>LLM: POST /api/generate (prompt + text)
+    LLM-->>CLI: {"date": "2024.01.15", "filename": "Verizon MyBill"}
+    CLI->>FS: rename to "2024.01.15 - Verizon MyBill.pdf"
+    FS-->>CLI: ok
+    CLI-->>User: "File renamed successfully"
+```
+"""
+
 import click
 import re
 import json
 import time
-import tiktoken
 from pathlib import Path
 import requests
 import pypdf
 from click import style
 
-DEFAULT_MODEL = "llama3.1:70b-instruct-q8_0"
+DEFAULT_MODEL = "gemma4:31b"
 MODEL_CONTEXT_MAP = {
     "llama3.1:70b-instruct-q8_0": 128000,
     "llama3.2:3b-instruct-fp16": 128000,
     "llama3.1:8b-instruct-fp16": 128000,
     "gemma3:27b": 128000,
+    "gemma4:31b": 128000,
 }
 
 
 def calculate_context_window(model: str, prompt: str) -> int:
-    """
-    Calculate the minimum required context window size for the given prompt.
+    """Calculate the num_ctx value to request from Ollama for a given prompt.
+
+    Adds a fixed 1000-character buffer to the prompt length to leave room for
+    the model's JSON response, then caps the result at the model's maximum
+    supported context size. Falls back to 2048 for unrecognised models.
 
     Args:
-        model (str): The model name
-        prompt (str): The prompt text
+        model: Ollama model tag, e.g. ``"gemma4:31b"``.
+        prompt: The fully-formatted prompt string that will be sent to Ollama.
 
     Returns:
-        int: The required context window size
+        The context window size to pass as ``num_ctx`` in the Ollama request.
+
+    Example:
+        >>> calculate_context_window("gemma4:31b", "x" * 500)
+        1500
     """
     try:
         prompt_length = len(prompt)
@@ -44,14 +98,23 @@ def calculate_context_window(model: str, prompt: str) -> int:
 
 
 def extract_pdf_text(pdf_path: Path) -> str:
-    """
-    Extracts text from a PDF file.
+    """Extract all text from a PDF file by concatenating every page.
 
     Args:
-        pdf_path (Path): Path to the PDF file.
+        pdf_path: Path to the PDF file to read.
 
     Returns:
-        str: Extracted text.
+        A single string containing the concatenated text of all pages.
+        Pages that yield no text contribute an empty string.
+
+    Raises:
+        pypdf.errors.PdfReadError: If the file is corrupted or not a valid PDF.
+        OSError: If the file cannot be opened.
+
+    Example:
+        >>> text = extract_pdf_text(Path("invoice.pdf"))
+        >>> print(text[:80])
+        'Invoice #1234 ...'
     """
     text = ""
     with pdf_path.open("rb") as file:
@@ -61,37 +124,57 @@ def extract_pdf_text(pdf_path: Path) -> str:
     return text
 
 
-def generate_new_filename(text: str, original_file: Path, model: str) -> str:
-    """
-    Generates a new filename based on PDF content and date extracted from the original filename.
+FAILED_DATE = "YYYY.MM.DD"
+FAILED_FILENAME = "Unknown Document"
+
+
+def generate_new_filename(text: str, original_file: Path, model: str) -> tuple:
+    """Query Ollama to produce a descriptive filename and date for a PDF.
+
+    Reads ``prompt.md`` from the current working directory, formats it with
+    the extracted PDF text, and sends the request to the local Ollama API at
+    ``http://127.0.0.1:11434``. The model is expected to return a JSON object
+    with exactly two keys: ``"date"`` and ``"filename"``.
+
+    When the model cannot determine a date, ``FAILED_DATE`` (``"YYYY.MM.DD"``)
+    is used as the date component. When the filename is absent or contains
+    ``"unknown"``, ``FAILED_FILENAME`` (``"Unknown Document"``) is substituted.
+    Filenames longer than 80 characters (including the date and separator) are
+    truncated with an ellipsis.
 
     Args:
-        text (str): The content of the PDF file.
-        original_file (Path): The original PDF file.
-        model (str): The LLM model to use for generating filenames.
+        text: Full text extracted from the PDF, used as the prompt body.
+        original_file: Path to the original PDF file (used for logging only).
+        model: Ollama model tag to use, e.g. ``"gemma4:31b"``.
 
     Returns:
-        str: The new filename.
+        A ``(date, filename)`` tuple on success, or ``None`` if the API
+        response is missing, malformed, or cannot be parsed.
+
+    Raises:
+        requests.exceptions.RequestException: On network or HTTP errors when
+            contacting the Ollama API.
+        FileNotFoundError: If ``prompt.md`` does not exist in the working
+            directory.
+
+    Example:
+        >>> result = generate_new_filename(text, Path("scan.pdf"), "gemma4:31b")
+        >>> result
+        ('2024.03.15', 'Verizon MyBill')
     """
-
-    max_summarized_length = 17
-
     # Read the prompt from 'prompt.md'
     prompt_path = Path("prompt.md")
     prompt = prompt_path.read_text()
     prompt = prompt.format(text=text)
 
     print(style("=" * 50, fg="blue"))
-    print(style("Prompt Analysis", fg="green", bold=True))
+    print(style(f"Prompt Analysis ({model})", fg="green", bold=True))
 
     # Calculate required context window
     context_window = calculate_context_window(model, prompt)
-    # Calculate tokens for performance tracking
-    encoding = tiktoken.encoding_for_model("gpt-4")
-    token_count = len(encoding.encode(prompt))
 
     print(
-        f"Sending prompt to Ollama (length: {len(prompt)} characters, context window: {context_window} tokens, input tokens: {token_count})"
+        f"Sending prompt to Ollama (length: {len(prompt)} characters, context window: {context_window})"
     )
 
     # Send the request to the Ollama service and measure time
@@ -109,10 +192,7 @@ def generate_new_filename(text: str, original_file: Path, model: str) -> str:
     )
     response.raise_for_status()
     elapsed_time = time.time() - start_time
-    tokens_per_second = token_count / elapsed_time
-    print(
-        f"Received response from Ollama in {elapsed_time:.2f} seconds ({tokens_per_second:.1f} tokens/second)"
-    )
+    print(f"Received response from Ollama in {elapsed_time:.2f} seconds")
     print(style("=" * 50, fg="blue"))
     try:
         data = response.json()
@@ -144,30 +224,82 @@ def generate_new_filename(text: str, original_file: Path, model: str) -> str:
             return None
 
         # Clean and validate the summarized name
-        date = data["date"].strip() if data["date"] else "YYYY.MM.DD"
+        date = data["date"].strip() if data["date"] else FAILED_DATE
         filename = data["filename"].strip()
+        if not filename or "unknown" in filename.lower():
+            filename = FAILED_FILENAME
 
         # Truncate filename if too long (accounting for date and separator)
-        max_length = 50
+        max_length = 80
         date_and_sep_len = len(date) + 3  # date + " - "
         if len(filename) > max_length - date_and_sep_len:
             filename = filename[: max_length - date_and_sep_len - 3] + "..."
 
-        summarized_name = f"{date} - {filename}"
-        return summarized_name
+        return (date, filename)
     except Exception as e:
         print(f"Error generating filename: {str(e)}")
         return None
 
 
-def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool = False):
-    """
-    Processes PDF files in the given directory.
+def format_filename(date: str, filename: str) -> str:
+    """Assemble the final filename string from a date and a name part.
+
+    Joins ``date`` and ``filename`` with `` - ``, strips any trailing ``.pdf``
+    suffix that may have been included in the LLM response, and removes a
+    trailing ellipsis (``...``) left by truncation logic in
+    ``generate_new_filename``.
 
     Args:
-        directory (Path): The directory containing PDF files.
-        test_mode (bool): Whether to run in test mode without renaming
-        model (str): The LLM model to use for generating filenames
+        date: Document date string in ``YYYY.MM.DD`` format, or the sentinel
+            ``"YYYY.MM.DD"`` when the date could not be determined.
+        filename: Descriptive name part, without extension.
+
+    Returns:
+        A filename string without extension, ready to have ``.pdf`` appended
+        before writing to disk.
+
+    Example:
+        >>> format_filename("2024.03.15", "Verizon MyBill")
+        '2024.03.15 - Verizon MyBill'
+    """
+    name = f"{date} - {filename}"
+    name = name.replace(".pdf", "")
+    if name.endswith("..."):
+        name = name[:-3].rstrip()
+    return name
+
+
+def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool = False, backup_model: str = None):
+    """Process and rename PDF files in a directory using LLM-generated names.
+
+    By default, only files whose names contain a timestamp in the format
+    ``YYYY_MM_DD_HH_MM_SS`` are processed. Pass ``all_files=True`` to process
+    every PDF in the directory.
+
+    For each file, ``extract_pdf_text`` and ``generate_new_filename`` are
+    called. If either the date or the filename component of the primary model's
+    response is a failure sentinel and ``backup_model`` is provided, the backup
+    model is queried and its successful fields are merged into the result.
+
+    In test mode the user is prompted to confirm each rename interactively.
+    In normal mode files are renamed immediately.
+
+    Args:
+        directory: Directory to scan for PDF files.
+        test_mode: When ``True``, prompt the user before each rename instead
+            of renaming automatically.
+        model: Primary Ollama model tag, e.g. ``"gemma4:31b"``.
+        all_files: When ``True``, process every PDF regardless of filename
+            pattern. When ``False`` (default), skip files that do not match
+            the ``YYYY_MM_DD_HH_MM_SS`` timestamp pattern.
+        backup_model: Optional Ollama model tag used as a fallback when the
+            primary model returns a failure sentinel for ``date`` or
+            ``filename``. Only the failed fields are replaced; successful
+            fields from the primary model are preserved.
+
+    Raises:
+        requests.exceptions.RequestException: Propagated per-file on network
+            failure; the file is skipped and processing continues.
     """
     # Get all PDF files first
     pdf_files = [
@@ -199,18 +331,30 @@ def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool =
         print(style(f"Processing {pdf_file.name}", fg="green", bold=True))
         try:
             text = extract_pdf_text(pdf_file)
-            new_filename = generate_new_filename(text, pdf_file, model)
-            if not new_filename:
+            result = generate_new_filename(text, pdf_file, model)
+            if not result:
                 print(f"Error processing {pdf_file.name}. Ignoring.")
                 continue
 
+            date, filename = result
+            has_bad_date = date == FAILED_DATE
+            has_bad_filename = filename == FAILED_FILENAME
+
+            # Retry with backup model if there's any failure
+            if backup_model and (has_bad_date or has_bad_filename):
+                print(style(f"Partial/total failure detected, retrying with backup model: {backup_model}", fg="yellow"))
+                backup_result = generate_new_filename(text, pdf_file, backup_model)
+                if backup_result:
+                    backup_date, backup_filename = backup_result
+                    if has_bad_date and backup_date != FAILED_DATE:
+                        date = backup_date
+                    if has_bad_filename and backup_filename != FAILED_FILENAME:
+                        filename = backup_filename
+
+            new_filename = format_filename(date, filename)
+
             print(f"Original filename:\t{pdf_file.name}")
             print(f"New filename:\t{new_filename}")
-
-            # Remove .pdf extension and trailing "..." if they exist
-            new_filename = new_filename.replace(".pdf", "")
-            if new_filename.endswith("..."):
-                new_filename = new_filename[:-3].rstrip()
 
             if test_mode:
                 if click.confirm("Do you want to rename this file?", default=False):
@@ -219,7 +363,6 @@ def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool =
                 else:
                     print(style("Skipping file rename in test mode", fg="yellow"))
             else:
-                # In non-test mode, rename without confirmation
                 pdf_file.rename(directory / f"{new_filename}.pdf")
                 print(style("File renamed successfully", fg="green"))
 
@@ -244,9 +387,14 @@ def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool =
     is_flag=True,
     help="Process all PDF files in the directory, regardless of filename pattern.",
 )
-def main(scan_directory, test_mode, model, all_files):
+@click.option(
+    "--backup-model",
+    default=None,
+    help="Backup model to retry when the primary model fails to extract date or filename.",
+)
+def main(scan_directory, test_mode, model, all_files, backup_model):
     """Process PDF files in the provided directory."""
-    process_pdfs(Path(scan_directory), test_mode, model, all_files)
+    process_pdfs(Path(scan_directory), test_mode, model, all_files, backup_model)
 
 
 if __name__ == "__main__":

--- a/pdf_renamer.py
+++ b/pdf_renamer.py
@@ -13,6 +13,7 @@ MODEL_CONTEXT_MAP = {
     "llama3.1:70b-instruct-q8_0": 128000,
     "llama3.2:3b-instruct-fp16": 128000,
     "llama3.1:8b-instruct-fp16": 128000,
+    "gemma3:27b": 128000,
 }
 
 
@@ -144,14 +145,14 @@ def generate_new_filename(text: str, original_file: Path, model: str) -> str:
 
         # Clean and validate the summarized name
         date = data["date"].strip() if data["date"] else "YYYY.MM.DD"
-        filename = data['filename'].strip()
-        
+        filename = data["filename"].strip()
+
         # Truncate filename if too long (accounting for date and separator)
         max_length = 50
         date_and_sep_len = len(date) + 3  # date + " - "
         if len(filename) > max_length - date_and_sep_len:
-            filename = filename[:max_length - date_and_sep_len - 3] + "..."
-            
+            filename = filename[: max_length - date_and_sep_len - 3] + "..."
+
         summarized_name = f"{date} - {filename}"
         return summarized_name
     except Exception as e:
@@ -207,10 +208,10 @@ def process_pdfs(directory: Path, test_mode: bool, model: str, all_files: bool =
             print(f"New filename:\t{new_filename}")
 
             # Remove .pdf extension and trailing "..." if they exist
-            new_filename = new_filename.replace('.pdf', '')
-            if new_filename.endswith('...'):
+            new_filename = new_filename.replace(".pdf", "")
+            if new_filename.endswith("..."):
                 new_filename = new_filename[:-3].rstrip()
-            
+
             if test_mode:
                 if click.confirm("Do you want to rename this file?", default=False):
                     pdf_file.rename(directory / f"{new_filename}.pdf")

--- a/prompt.md
+++ b/prompt.md
@@ -22,6 +22,8 @@ Here are some examples to help you, respond only using JSON format, conforming t
 {{"filename": "Carmax Sale Amanda Macan.pdf", "date": "2024.04.26"}}
 {{"filename": "Some reference document.pdf", "date": null}}
 
+IMPORTANT: The total filename (including date and " - " separator) must not exceed 80 characters. Keep the filename portion concise.
+
 Now here is the file:
 
 ```pdf{text}```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,102 @@
+# =============================================================================
+# BUILD SYSTEM
+# =============================================================================
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+# =============================================================================
+# PROJECT METADATA
+# =============================================================================
+
+[project]
+name = "pdf-namer"
+version = "0.2.0"
+description = "CLI tool that renames PDF files using local LLM-generated descriptive filenames"
+readme = "README.md"
+license = {text = "BSD-2-Clause"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+    "pypdf~=3.17",
+    "requests~=2.31",
+    "click~=8.1",
+]
+requires-python = "~=3.11"
+
+[project.optional-dependencies]
+dev = [
+    # Testing
+    "pytest~=7.4",
+    "pytest-cov~=4.1",
+    "pytest-mock~=3.12",
+    "requests-mock~=1.11",
+    # Code quality
+    "black~=24.12.0",
+    "flake8~=7.1.0",
+    "flake8-pyproject~=1.2.0",
+    "bandit[toml]~=1.8.0",
+    "vulture~=2.14",
+]
+
+[project.scripts]
+pdf-namer = "pdf_renamer:main"
+
+# =============================================================================
+# CODE QUALITY TOOLS
+# =============================================================================
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503", "E501"]
+exclude = [".venv", ".git", "__pycache__", "build", "dist"]
+per-file-ignores = [
+    "__init__.py:F401",
+]
+
+[tool.bandit]
+exclude_dirs = [".venv", "tests"]
+skips = ["B101"]
+
+[tool.vulture]
+exclude = [".venv/"]
+min_confidence = 80
+
+# =============================================================================
+# TESTING
+# =============================================================================
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = "test_*.py"
+python_functions = "test_*"
+python_classes = "Test*"
+addopts = [
+    "--verbose",
+    "--tb=short",
+    "--strict-markers",
+    "--disable-warnings",
+]
+
+[tool.coverage.run]
+source = ["."]
+branch = true
+omit = ["test_*.py", ".venv/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ build-backend = "hatchling.build"
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+only-include = ["pdf_renamer.py"]
+
 # =============================================================================
 # PROJECT METADATA
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,11 @@ dev = [
     "pytest-mock~=3.12",
     "requests-mock~=1.11",
     # Code quality
-    "black~=24.12.0",
-    "flake8~=7.1.0",
-    "flake8-pyproject~=1.2.0",
-    "bandit[toml]~=1.8.0",
-    "vulture~=2.14",
+    "black>=24.0",
+    "flake8>=7.0",
+    "flake8-pyproject>=1.2",
+    "bandit[toml]>=1.8",
+    "vulture>=2.14",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "black>=24.0",
     "flake8>=7.0",
     "flake8-pyproject>=1.2",
-    "bandit[toml]~=1.9",
+    "bandit[toml]>=1.8",
     "vulture>=2.14",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "black>=24.0",
     "flake8>=7.0",
     "flake8-pyproject>=1.2",
-    "bandit[toml]>=1.8",
+    "bandit[toml]~=1.9",
     "vulture>=2.14",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pypdf==3.17.1
-requests==2.31.0
-pytest==7.4.3
-pytest-mock==3.12.0
-pytest-cov==4.1.0
-requests-mock==1.11.0
-click==8.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pypdf==3.17.1
-tiktoken==0.5.2
 requests==2.31.0
 pytest==7.4.3
 pytest-mock==3.12.0

--- a/test_pdf_renamer.py
+++ b/test_pdf_renamer.py
@@ -44,8 +44,8 @@ class TestGenerateNewFilename:
                 "response": '{"date": "2023.10.12", "filename": "Sample Name"}'
             }
             mock_post.return_value.raise_for_status = MagicMock()
-            new_filename = pdf_renamer.generate_new_filename(sample_text, original_file, "llama2")
-            assert new_filename == "2023.10.12 - Sample Name"
+            result = pdf_renamer.generate_new_filename(sample_text, original_file, "llama2")
+            assert result == ("2023.10.12", "Sample Name")
 
     def test_network_error(self):
         sample_text = "Sample PDF content"
@@ -62,8 +62,8 @@ class TestGenerateNewFilename:
                 "response": '{"date": "UnknownDate", "filename": "Sample Name"}'
             }
             mock_post.return_value.raise_for_status = MagicMock()
-            new_filename = pdf_renamer.generate_new_filename(sample_text, original_file, "llama2")
-            assert new_filename.startswith("UnknownDate - ")
+            result = pdf_renamer.generate_new_filename(sample_text, original_file, "llama2")
+            assert result[0] == "UnknownDate"
 
     def test_missing_response_key(self):
         sample_text = "Sample PDF content"
@@ -84,9 +84,10 @@ class TestGenerateNewFilename:
                 "response": '{"date": "2023.10.12", "filename": "This is a very long filename that should be handled properly"}'
             }
             mock_post.return_value.raise_for_status = MagicMock()
-            new_filename = pdf_renamer.generate_new_filename(sample_text, original_file, "llama2")
-            assert len(new_filename) <= 50  # Adjusted for new requirements
-            assert ' - ' in new_filename
+            result = pdf_renamer.generate_new_filename(sample_text, original_file, "llama2")
+            formatted = pdf_renamer.format_filename(*result)
+            assert len(formatted) <= 80
+            assert ' - ' in formatted
 
 class TestContextWindow:
     def test_calculate_context_window(self):
@@ -115,10 +116,10 @@ class TestProcessPdfs:
         with patch('pdf_renamer.extract_pdf_text') as mock_extract, \
              patch('pdf_renamer.generate_new_filename') as mock_generate, \
              patch('click.confirm') as mock_confirm:
-            
+
             mock_extract.return_value = "Test content"
-            mock_generate.return_value = "2023.10.12 - Test Doc.pdf"
-            
+            mock_generate.return_value = ("2023.10.12", "Test Doc")
+
             # Test when user confirms rename
             mock_confirm.return_value = True
             pdf_renamer.process_pdfs(tmp_path, test_mode=True, model="llama2")
@@ -127,7 +128,7 @@ class TestProcessPdfs:
 
             # Reset the test environment
             (tmp_path / "2023.10.12 - Test Doc.pdf").rename(pdf_file)
-            
+
             # Test when user declines rename
             mock_confirm.return_value = False
             pdf_renamer.process_pdfs(tmp_path, test_mode=True, model="llama2")
@@ -139,54 +140,99 @@ class TestProcessPdfs:
         with patch('pdf_renamer.process_pdfs') as mock_process:
             result = runner.invoke(pdf_renamer.main, ['--test-mode', '--model', 'llama2', str(tmp_path)])
             assert result.exit_code == 0
-            mock_process.assert_called_once_with(Path(tmp_path), True, 'llama2', False)
+            mock_process.assert_called_once_with(Path(tmp_path), True, 'llama2', False, None)
 
     def test_main_with_all_files(self, tmp_path):
         runner = CliRunner()
         with patch('pdf_renamer.process_pdfs') as mock_process:
             result = runner.invoke(pdf_renamer.main, ['--all-files', '--model', 'llama2', str(tmp_path)])
             assert result.exit_code == 0
-            mock_process.assert_called_once_with(Path(tmp_path), False, 'llama2', True)
+            mock_process.assert_called_once_with(Path(tmp_path), False, 'llama2', True, None)
+
+    def test_main_with_backup_model(self, tmp_path):
+        runner = CliRunner()
+        with patch('pdf_renamer.process_pdfs') as mock_process:
+            result = runner.invoke(pdf_renamer.main, ['--model', 'llama2', '--backup-model', 'gemma3:27b', str(tmp_path)])
+            assert result.exit_code == 0
+            mock_process.assert_called_once_with(Path(tmp_path), False, 'llama2', False, 'gemma3:27b')
+
     def test_empty_directory(self, tmp_path):
         pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2")
         assert len(list(tmp_path.iterdir())) == 0
 
     def test_successful_processing(self, tmp_path):
-        # Create test PDF files
         pdf_file = tmp_path / "2023_10_12_13_14_15_sample.pdf"
         pdf_file.write_bytes(b"%PDF-1.4")
-        
+
         with patch('pdf_renamer.extract_pdf_text') as mock_extract, \
              patch('pdf_renamer.generate_new_filename') as mock_generate:
             mock_extract.return_value = "Test content"
-            mock_generate.return_value = "2023.10.12 - Test Doc.pdf"
-            
+            mock_generate.return_value = ("2023.10.12", "Test Doc")
+
             pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2")
             assert not pdf_file.exists()
             assert (tmp_path / "2023.10.12 - Test Doc.pdf").exists()
 
-    def test_skip_large_content(self, tmp_path):
-        # Create a PDF file with large content
+    def test_backup_model_on_bad_date(self, tmp_path):
         pdf_file = tmp_path / "2023_10_12_13_14_15_sample.pdf"
         pdf_file.write_bytes(b"%PDF-1.4")
-        
-        with patch('pdf_renamer.extract_pdf_text') as mock_extract:
-            mock_extract.return_value = "x" * 10001  # Create text longer than 10000 chars
+
+        with patch('pdf_renamer.extract_pdf_text') as mock_extract, \
+             patch('pdf_renamer.generate_new_filename') as mock_generate:
+            mock_extract.return_value = "Test content"
+            # Primary returns bad date, good filename; backup returns good date
+            mock_generate.side_effect = [
+                ("YYYY.MM.DD", "Evelyn Oral Health Assessment"),
+                ("2023.10.12", "Some Other Name"),
+            ]
+
+            pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2", backup_model="gemma3:27b")
+            assert not pdf_file.exists()
+            # Should merge: date from backup, filename from primary
+            assert (tmp_path / "2023.10.12 - Evelyn Oral Health Assessment.pdf").exists()
+
+    def test_backup_model_on_total_failure(self, tmp_path):
+        pdf_file = tmp_path / "2023_10_12_13_14_15_sample.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4")
+
+        with patch('pdf_renamer.extract_pdf_text') as mock_extract, \
+             patch('pdf_renamer.generate_new_filename') as mock_generate:
+            mock_extract.return_value = "Test content"
+            # Primary returns bad date and bad filename; backup returns both good
+            mock_generate.side_effect = [
+                ("YYYY.MM.DD", "Unknown Document"),
+                ("2023.10.12", "Good Filename"),
+            ]
+
+            pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2", backup_model="gemma3:27b")
+            assert not pdf_file.exists()
+            assert (tmp_path / "2023.10.12 - Good Filename.pdf").exists()
+
+    def test_no_retry_without_backup_model(self, tmp_path):
+        pdf_file = tmp_path / "2023_10_12_13_14_15_sample.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4")
+
+        with patch('pdf_renamer.extract_pdf_text') as mock_extract, \
+             patch('pdf_renamer.generate_new_filename') as mock_generate:
+            mock_extract.return_value = "Test content"
+            mock_generate.return_value = ("YYYY.MM.DD", "Some Doc")
+
             pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2")
-            assert pdf_file.exists()  # File should not be processed due to length
+            # Should still rename with the bad date since no backup
+            assert not pdf_file.exists()
+            assert (tmp_path / "YYYY.MM.DD - Some Doc.pdf").exists()
 
     def test_skip_non_matching_files(self, tmp_path):
-        # Create a PDF file without date pattern
         pdf_file = tmp_path / "regular.pdf"
         pdf_file.write_bytes(b"%PDF-1.4")
-        
+
         pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2")
-        assert pdf_file.exists()  # File should not be processed
+        assert pdf_file.exists()
 
     def test_permission_error(self, tmp_path):
         pdf_file = tmp_path / "2023_10_12_13_14_15_sample.pdf"
         pdf_file.write_bytes(b"%PDF-1.4")
-        
+
         with patch('pathlib.Path.rename', side_effect=PermissionError):
             pdf_renamer.process_pdfs(tmp_path, test_mode=False, model="llama2")
-            assert pdf_file.exists()  # Original file should still exist
+            assert pdf_file.exists()


### PR DESCRIPTION
## Summary

- Switch default model from llama3.1:70b to gemma4:31b
- Add --backup-model CLI flag for automatic retry/merge when the primary model fails to extract date or filename (partial failures merge the best fields from each model)
- Remove tiktoken dependency (was using OpenAI's tokenizer to estimate token counts for a local Ollama model — inaccurate and unnecessary)
- Increase filename max length from 50 to 80 characters, informed by APFS/OneDrive/Synology limits
- Add pyproject.toml with dev tooling config (black, flake8, bandit, vulture, pytest)
- Update README, add CONTRIBUTING.md
- Add Google-style docstrings to all public functions

## Test plan

- [x] All 22 tests pass (including 3 new backup model tests)
- [ ] Manual test with gemma4:31b on a directory of PDFs
- [ ] Manual test with --backup-model gemma3:27b to verify retry/merge behavior
- [ ] Verify --test-mode still prompts before rename